### PR TITLE
Lower avatars rendered on /login to 1000 for performance reasons

### DIFF
--- a/web/views/login.jade
+++ b/web/views/login.jade
@@ -20,7 +20,7 @@ html
 	body.login(style='background-color: black !important;')
 		.avatars
 			ul
-				each avatarFile in Mikuia.Tools.getAvatars(10000)
+				each avatarFile in Mikuia.Tools.getAvatars(1000)
 					li
 						img(src='/img/avatars/' + avatarFile, width='64', height='64')
 


### PR DESCRIPTION
Loading 10k images as a background has a huge performance impact on rendering, especially when on laptops or even tablets. Lowered it to 1k, this significantly increased render time while still having a full background of avatars on a full HD screen. Bigger resolutions will see black, but then I'd suggest finding a different way to solve that rather than putting extra load on devices that are way more common.